### PR TITLE
Fixed typo of bzr-builddeb in license

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -354,7 +354,7 @@ is distributed under the following terms::
 
    This file is part of breezy-debian.
 
-   bzr-builldeb is free software; you can redistribute it and/or modify
+   bzr-builddeb is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 2 of the License, or
    (at your option) any later version.


### PR DESCRIPTION
This pull request fixes the license part which originally had `bzr-builddeb` in the first paragraph. I have fixed it so it says `bzr-builddeb`.