### PR TITLE
Update python-apt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "breezy>=3.3.0.dev.0",
     "debmutate[watch]>=0.60",
     "python_debian",
-    "python-apt",
+    "python-apt@git+https://salsa.debian.org/apt-team/python-apt",    # python-apt-binary
     "distro-info",
 ]
 version = "2.8.78"


### PR DESCRIPTION
Searching: [pypi.org](https://pypi.org/search/?q=python-apt), there isn't any results for `python-apt`
As a resuilt, trying to install:
> ERROR: Could not find a version that satisfies the requirement python-apt (from brz-debian) (from versions: none)
> ERROR: No matching distribution found for python-apt

From previous experience, I believe what is desired is: <https://salsa.debian.org/apt-team/python-apt>.

- - -

Checking pypi.org, there is [python-apt-binary](https://pypi.org/project/python-apt-binary/).

As this is a little behind on whats on [salsa.debian.org](https://salsa.debian.org/apt-team/python-apt/-/tags) (v2.9.8) (PyPi is [2.6.0](https://pypi.org/project/python-apt-binary/#history)), opt'ing not to go with it