### PR TITLE
Fix AptSource to fall back to Checksums-Sha256 when Files field is absent

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+breezy-debian (2.8.82) UNRELEASED; urgency=medium
+
+  * Fix AptSource to fall back to Checksums-Sha256 when Files field is
+    absent from apt Sources index.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Sat, 14 Mar 2026 19:38:37 +0000
+
 breezy-debian (2.8.81) unstable; urgency=medium
 
   * Fix test failures with newer dpkg-source that validates Maintainer

--- a/tests/test_upstream.py
+++ b/tests/test_upstream.py
@@ -102,6 +102,20 @@ def MockSource(name, version, files):
     return dsc
 
 
+def MockSourceSha256(name, version, files):
+    """Create a mock source with only Checksums-Sha256, no Files field.
+
+    This simulates what apt returns when the Sources index has dropped
+    MD5 checksums.
+    """
+    dsc = Dsc({"Package": name, "Version": version})
+    dsc["Checksums-Sha256"] = [
+        {"sha256": checksum, "size": size, "name": name}
+        for (checksum, size, name, kind) in files
+    ]
+    return dsc
+
+
 class MockApt(Apt):
     def __init__(self, sources):
         self._sources = sources
@@ -217,6 +231,24 @@ class AptSourceTests(TestCase):
             "apackage", "0.1-1", [("checksum", 0, "apackage_0.1.orig.tar.gz", "tar")]
         )
         source2 = MockSource(
+            "apackage", "0.2-1", [("checksum", 0, "apackage_0.2.orig.tar.gz", "tar")]
+        )
+        apt = MockApt([source1, source2])
+        caller = MockAptCaller()
+        apt._run_apt_source = caller.call
+        src = AptSource(apt)
+        paths = src.fetch_tarballs("apackage", "0.2", "target")
+        self.assertEqual(paths, ["target/apackage_0.2.orig.tar.gz"])
+        self.assertEqual(1, caller.called)
+        self.assertEqual("apackage", caller.package)
+        self.assertEqual("0.2-1", caller.version_str)
+        self.assertEqual("target", caller.target_dir)
+
+    def test_apt_provider_sha256_only(self):
+        source1 = MockSourceSha256(
+            "apackage", "0.1-1", [("checksum", 0, "apackage_0.1.orig.tar.gz", "tar")]
+        )
+        source2 = MockSourceSha256(
             "apackage", "0.2-1", [("checksum", 0, "apackage_0.2.orig.tar.gz", "tar")]
         )
         apt = MockApt([source1, source2])

--- a/upstream/__init__.py
+++ b/upstream/__init__.py
@@ -162,7 +162,17 @@ class AptSource(UpstreamSource):
             try:
                 for source in self.apt.iter_source_by_name(package):
                     filenames = []
-                    for entry in source["Files"]:
+                    for checksum_field in [
+                        "Files",
+                        "Checksums-Sha256",
+                        "Checksums-Sha1",
+                    ]:
+                        if checksum_field in source:
+                            file_entries = source[checksum_field]
+                            break
+                    else:
+                        continue
+                    for entry in file_entries:
                         filename = os.path.basename(entry["name"])
                         if filename.startswith(
                             "{}_{}.orig".format(package, upstream_version)


### PR DESCRIPTION
Debian's apt repositories have dropped the Files field (MD5 checksums) from Sources indices, keeping only Checksums-Sha256. This caused a KeyError when AptSource tried to access source["Files"].

Fall back to Checksums-Sha256 or Checksums-Sha1 when Files is not present, as all these fields contain the same name/size sub-fields needed to identify orig tarballs.